### PR TITLE
[PKG-13413] Update to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ about:
     completions sent with the official Anthropic library.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
-  run_constrained:
-    - anthropic >=0.36.0
 
 # Tests disabled, fixture not found @pytest.mark.vcr -> pytest-vcr -> https://pypi.org/project/pytest-vcr/
 test:
@@ -36,7 +34,7 @@ test:
     - pip check
   requires:
     - pip
-    - anthropic >=0.36.0
+    - anthropic
 
 about:
   home: https://www.traceloop.com/openllmetry

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-anthropic" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,24 +7,24 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_anthropic-{{ version }}.tar.gz
-  sha256: 7f2180938a5adfc3026689ddec0169b67bca2aa1593d9da9c99a1285df6c0386
+  sha256: 169270a3c6b9ce49c3d8c7dbf6e13cea0d20c37938dcbddbf2f30450f596dcc6
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5.0
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
   run_constrained:
     - anthropic >=0.36.0
 
@@ -43,9 +43,14 @@ about:
   dev_url: https://github.com/traceloop/openllmetry
   doc_url: https://www.traceloop.com/docs/openllmetry/introduction
   summary: OpenTelemetry Anthropic instrumentation
+  description: |
+    This library allows tracing Anthropic prompts and 
+    completions sent with the official Anthropic library.
   license: Apache-2.0
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - timkpaine
+  skip-lints:
+    - reachable_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,15 +26,35 @@ requirements:
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
 
-# Tests disabled, fixture not found @pytest.mark.vcr -> pytest-vcr -> https://pypi.org/project/pytest-vcr/
+#AttributeError: module 'opentelemetry.semconv._incubating.attributes.gen_ai_attributes' has no attribute 'GEN_AI_TOOL_DEFINITIONS'
+# No module pytest-vcr installed, so we ignore tests that require it.
+# Ignored tests:
+{% set ignored_tests = [
+  "--ignore=tests/test_completion.py",
+  "--ignore=tests/test_messages.py",
+  "--ignore=tests/test_prompt_caching.py",
+  "--ignore=tests/test_thinking.py",
+  "--ignore=tests/test_bedrock_with_raw_response.py",
+  "--ignore=tests/test_structured_outputs.py",
+  "--deselect=tests/test_semconv_span_attrs.py::test_tool_definitions_attribute"
+] %}
+
 test:
   imports:
     - opentelemetry.instrumentation.anthropic
+  source_files:
+    - tests
+    - pyproject.toml
   commands:
     - pip check
+    - pytest -vvv {{ " ".join(ignored_tests) }}
   requires:
     - pip
+    - boto3
+    - pytest
     - anthropic
+    - pytest-asyncio
+    - opentelemetry-sdk
 
 about:
   home: https://www.traceloop.com/openllmetry
@@ -51,5 +71,3 @@ about:
 extra:
   recipe-maintainers:
     - timkpaine
-  skip-lints:
-    - reachable_url


### PR DESCRIPTION
opentelemetry-instrumentation-anthropic 0.57.0

**Destination channel:** defaults

### Links

- [PKG-13413] 
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0/packages/opentelemetry-instrumentation-anthropic)

### Explanation of changes:

- Swap build system to hatchling
- Remove run_constrained pinning on anthropic
- Adjust skip lint name.


[PKG-13413]: https://anaconda.atlassian.net/browse/PKG-13413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ